### PR TITLE
availability calculation fixed

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -69,14 +69,14 @@ V62    1    1    0.371828    14.98    H1    ROUND 15    MCC1    461 (7:41:0)    
 V63    1    2    0.371828    15.04    A4    ROUND 8    MCC1    461 (7:41:0)    996.422 (16:36:25)    1012.72 (16:52:42)    1027.76 (17:7:45)    1053.5 (17:33:29)    
 V64    1    2    0.371828    15.04    H2    ROUND 17    MCC1    461 (7:41:0)    1012.96 (16:52:57)    1013.51 (16:53:30)    1028.55 (17:8:32)    1033.67 (17:13:40)    
 ---
-Choosing ambulance A1 with min_av= 27660 cl= 28.4631 of priority 114.97
-Choosing ambulance A1 with min_av= 27660 cl= 23.6298 of priority 111.104
-Choosing ambulance A2 with min_av= 27660 cl= 30.1853 of priority 116.348
-Choosing ambulance A3 with min_av= 32359.4 cl= 17.8724 of priority 122.163
-Choosing ambulance A1 with min_av= 32690.1 cl= 23.9053 of priority 128.091
-Choosing ambulance A4 with min_av= 42423.2 cl= 18.0391 of priority 155.842
-Choosing ambulance A3 with min_av= 42945.7 cl= 35.928 of priority 171.895
-Choosing ambulance A4 with min_av= 50175 cl= 23.0947 of priority 185.726
+Choosing ambulance A1 with min_av= 27660 cl= 28.4631 of priority 22.7705
+Choosing ambulance A1 with min_av= 27660 cl= 23.6298 of priority 18.9038
+Choosing ambulance A2 with min_av= 27660 cl= 30.1853 of priority 24.1483
+Choosing ambulance A3 with min_av= 32359.4 cl= 17.8724 of priority 29.9628
+Choosing ambulance A1 with min_av= 32690.1 cl= 23.9053 of priority 35.8914
+Choosing ambulance A4 with min_av= 42423.2 cl= 18.0391 of priority 63.642
+Choosing ambulance A3 with min_av= 42945.7 cl= 35.928 of priority 79.6947
+Choosing ambulance A4 with min_av= 50175 cl= 23.0947 of priority 93.5257
 ===
 PERIOD 1 HEURISTIC SOLUTION WITH QUALITY 15525.6
 V1    3    1    5.10496    93.3    A1    ROUND 2    MCC1    461 (7:41:0)    544.836 (9:4:50)    565.796 (9:25:47)    659.096 (10:59:5)    686.56 (11:26:33)    
@@ -257,9 +257,9 @@ V106    1    2    0.371828    15.04    H1    ROUND 19    MCC2    566 (9:26:0)   
 V107    1    2    0.371828    15.04    H2    ROUND 20    MCC2    566 (9:26:0)    1183.47 (19:43:28)    1185.15 (19:45:9)    1200.19 (20:0:11)    1206.2 (20:6:11)    
 V108    1    2    0.371828    15.04    A2    ROUND 17    MCC2    566 (9:26:0)    1167.82 (19:27:49)    1176.74 (19:36:44)    1191.78 (19:51:47)    1207.08 (20:7:4)    
 ---
-Choosing ambulance A2 with min_av= 37159.3 cl= 5.50538 of priority 128.269
-Choosing ambulance A4 with min_av= 49789.2 cl= 4.66128 of priority 169.693
-Choosing ambulance A3 with min_av= 50952.3 cl= 16.4276 of priority 182.983
+Choosing ambulance A2 with min_av= 37159.3 cl= 5.50538 of priority 15.0687
+Choosing ambulance A4 with min_av= 49789.2 cl= 4.66128 of priority 56.4931
+Choosing ambulance A3 with min_av= 50952.3 cl= 16.4276 of priority 69.783
 ===
 PERIOD 2 HEURISTIC SOLUTION WITH QUALITY 29126.9
 V1    3    1    5.10496    93.3    A1    ROUND 2    MCC1    461 (7:41:0)    544.836 (9:4:50)    565.796 (9:25:47)    659.096 (10:59:5)    686.56 (11:26:33)    
@@ -525,11 +525,11 @@ V147    1    2    0.371828    15.04    H1    ROUND 21    MCC2    706 (11:46:0)  
 V148    1    1    0.371828    14.98    A7    ROUND 12    MCC2    706 (11:46:0)    1199.99 (19:59:59)    1226.09 (20:26:5)    1241.07 (20:41:4)    1267.16 (21:7:9)    
 V149    1    2    0.371828    15.04    A4    ROUND 13    MCC1    706 (11:46:0)    1227.03 (20:27:1)    1244.9 (20:44:54)    1259.94 (20:59:56)    1282.24 (21:22:14)    
 ---
-Choosing ambulance A2 with min_av= 47416.6 cl= 4.66128 of priority 161.784
-Choosing ambulance A2 with min_av= 50988.6 cl= 16.4276 of priority 183.104
-Choosing ambulance A1 with min_av= 55190.9 cl= 21.7053 of priority 201.334
-Choosing ambulance A6 with min_av= 55424.5 cl= 14.7609 of priority 196.557
-Choosing ambulance A5 with min_av= 58656.9 cl= 8.66128 of priority 202.452
+Choosing ambulance A2 with min_av= 47416.6 cl= 4.66128 of priority 20.5843
+Choosing ambulance A2 with min_av= 50988.6 cl= 16.4276 of priority 41.904
+Choosing ambulance A1 with min_av= 55190.9 cl= 21.7053 of priority 60.1341
+Choosing ambulance A6 with min_av= 55424.5 cl= 14.7609 of priority 55.3571
+Choosing ambulance A5 with min_av= 58656.9 cl= 8.66128 of priority 61.252
 ===
 PERIOD 3 HEURISTIC SOLUTION WITH QUALITY 39183.5
 V1    3    1    5.10496    93.3    A1    ROUND 2    MCC1    461 (7:41:0)    544.836 (9:4:50)    565.796 (9:25:47)    659.096 (10:59:5)    686.56 (11:26:33)    
@@ -867,11 +867,11 @@ V178    1    1    0.371828    14.98    A3    ROUND 16    MCC1    806 (13:26:0)  
 V179    1    2    0.371828    15.04    H1    ROUND 28    MCC1    806 (13:26:0)    1426.09 (23:46:5)    1426.39 (23:46:23)    1441.43 (24:1:25)    1456.57 (24:16:34)    
 V180    1    2    0.371828    15.04    A2    ROUND 17    MCC1    806 (13:26:0)    1423.87 (23:43:52)    1447.36 (24:7:21)    1462.4 (24:22:24)    1484.09 (24:44:5)    
 ---
-Choosing ambulance A7 with min_av= 52513.8 cl= 12.872 of priority 185.344
-Choosing ambulance A1 with min_av= 52777.8 cl= 11.5942 of priority 185.201
-Choosing ambulance A5 with min_av= 55918 cl= 14.7609 of priority 198.202
-Choosing ambulance A3 with min_av= 62857 cl= 18.5947 of priority 224.399
-Choosing ambulance A3 with min_av= 62857 cl= 17.6502 of priority 223.644
+Choosing ambulance A7 with min_av= 52513.8 cl= 12.872 of priority 24.1437
+Choosing ambulance A1 with min_av= 52777.8 cl= 11.5942 of priority 24.0012
+Choosing ambulance A5 with min_av= 55918 cl= 14.7609 of priority 37.0019
+Choosing ambulance A3 with min_av= 62857 cl= 18.5947 of priority 63.1991
+Choosing ambulance A3 with min_av= 62857 cl= 17.6502 of priority 62.4435
 ===
 PERIOD 4 HEURISTIC SOLUTION WITH QUALITY 45888.7
 V1    3    1    5.10496    93.3    A1    ROUND 2    MCC1    461 (7:41:0)    544.836 (9:4:50)    565.796 (9:25:47)    659.096 (10:59:5)    686.56 (11:26:33)    
@@ -1257,9 +1257,9 @@ V195    1    2    0.371828    15.04    A5    ROUND 15    MCC1    936 (15:36:0)  
 V196    1    2    0.371828    15.04    H2    ROUND 31    MCC1    936 (15:36:0)    1499.46 (24:59:27)    1501.56 (25:1:33)    1516.6 (25:16:35)    1522.56 (25:22:33)    
 V197    1    1    0.371828    14.98    H2    ROUND 32    MCC6    936 (15:36:0)    1522.56 (25:22:33)    1524.49 (25:24:29)    1539.47 (25:39:28)    1548.14 (25:48:8)    
 ---
-Choosing ambulance A4 with min_av= 57861.3 cl= 29.7409 of priority 216.664
-Choosing ambulance A6 with min_av= 60678 cl= 18.0391 of priority 216.691
-Choosing ambulance A3 with min_av= 70495.4 cl= 8.66128 of priority 241.914
+Choosing ambulance A4 with min_av= 57861.3 cl= 29.7409 of priority 29.4635
+Choosing ambulance A6 with min_av= 60678 cl= 18.0391 of priority 29.4913
+Choosing ambulance A3 with min_av= 70495.4 cl= 8.66128 of priority 54.7136
 ===
 PERIOD 5 HEURISTIC SOLUTION WITH QUALITY 50561.5
 V1    3    1    5.10496    93.3    A1    ROUND 2    MCC1    461 (7:41:0)    544.836 (9:4:50)    565.796 (9:25:47)    659.096 (10:59:5)    686.56 (11:26:33)    
@@ -1674,10 +1674,10 @@ V207    1    2    0.371828    15.04    H3    ROUND 28    MCC6    1096 (18:16:0) 
 V208    1    2    0.371828    15.04    A2    ROUND 18    MCC1    1096 (18:16:0)    1561.41 (26:1:24)    1587.87 (26:27:52)    1602.91 (26:42:54)    1629.37 (27:9:22)    
 V209    1    2    0.371828    15.04    H2    ROUND 34    MCC6    1096 (18:16:0)    1579.24 (26:19:14)    1581.17 (26:21:10)    1596.21 (26:36:12)    1604.92 (26:44:55)    
 ---
-Choosing ambulance A6 with min_av= 66929.9 cl= 26.4631 of priority 244.27
-Choosing ambulance A4 with min_av= 67850.8 cl= 29.1853 of priority 249.518
-Choosing ambulance A3 with min_av= 68313.2 cl= 24.0742 of priority 246.97
-Choosing ambulance A7 with min_av= 71718.3 cl= 29.7409 of priority 262.854
+Choosing ambulance A6 with min_av= 66929.9 cl= 26.4631 of priority 25.0701
+Choosing ambulance A4 with min_av= 67850.8 cl= 29.1853 of priority 30.3177
+Choosing ambulance A3 with min_av= 68313.2 cl= 24.0742 of priority 27.7702
+Choosing ambulance A7 with min_av= 71718.3 cl= 29.7409 of priority 43.6537
 ===
 PERIOD 6 HEURISTIC SOLUTION WITH QUALITY 47443.4
 V1    3    1    5.10496    93.3    A1    ROUND 2    MCC1    461 (7:41:0)    544.836 (9:4:50)    565.796 (9:25:47)    659.096 (10:59:5)    686.56 (11:26:33)    
@@ -2109,7 +2109,7 @@ V212    2    2    0.895303    29.9    A7    ROUND 7    MCC6    1176 (19:36:0)   
 V213    1    2    0.371828    15.04    H3    ROUND 27    MCC6    1176 (19:36:0)    1565.76 (26:5:45)    1567.69 (26:7:41)    1582.73 (26:22:43)    1591.39 (26:31:23)    
 V214    1    2    0.371828    15.04    A5    ROUND 18    MCC6    1176 (19:36:0)    1575.95 (26:15:56)    1605.13 (26:45:7)    1620.17 (27:0:10)    1651.16 (27:31:9)    
 ---
-Choosing ambulance A3 with min_av= 73722.1 cl= 31.5437 of priority 270.975
+Choosing ambulance A3 with min_av= 73722.1 cl= 31.5437 of priority 35.7755
 ===
 PERIOD 7 HEURISTIC SOLUTION WITH QUALITY 45054.6
 V1    3    1    5.10496    93.3    A1    ROUND 2    MCC1    461 (7:41:0)    544.836 (9:4:50)    565.796 (9:25:47)    659.096 (10:59:5)    686.56 (11:26:33)    

--- a/solver.cpp
+++ b/solver.cpp
@@ -256,7 +256,7 @@ void Solver::heuristicProcedure(float closeness_factor, float availability_facto
                     closeness += instance->getVehiclePrepTime(z, TYPE_AMBULANCE);
                 }
                 availability = instance->getVehicleOccupiedUntilTime(z, 0);
-                amb_priority = closeness * closeness_factor + (availability / 60.0) * availability_factor;
+                amb_priority = closeness * closeness_factor + ((availability - current_time) / 60.0) * availability_factor;
                 if (amb_priority < min_amb_priority && instance->getVehicleAppearTime(z, TYPE_AMBULANCE) <= current_time)
                 {
                     min_amb_priority = amb_priority;


### PR DESCRIPTION
uso directo de availability descartado para seleccion de ambulancia - se opta por uso de "cantidad de minutos de espera entre hora actual y primera hora en que vehiculo se disponibiliza"